### PR TITLE
Rename Fin constructors to FS and FZ

### DIFF
--- a/fin/ChangeLog.md
+++ b/fin/ChangeLog.md
@@ -1,5 +1,10 @@
 # Revision history for fin
 
+## 0.1
+
+- Rename `Fin` constructors to `FZ` and `FS`.
+  Now you can have both `Nat` and `Fin` imported unqualified in a single module.
+
 ## 0.0.3
 
 - Add `Data.Type.Nat.LE`, `Data.Type.Nat.LT` and `Data.Type.Nat.LE.ReflStep`

--- a/fin/cabal.project
+++ b/fin/cabal.project
@@ -1,1 +1,2 @@
 packages: .
+packages: ../dec

--- a/fin/fin.cabal
+++ b/fin/fin.cabal
@@ -1,6 +1,6 @@
 cabal-version:      >=1.10
 name:               fin
-version:            0.0.3
+version:            0.1
 synopsis:           Nat and Fin: peano naturals and finite numbers
 category:           Data, Dependent Types, Singletons
 description:

--- a/fin/src/Data/Fin.hs
+++ b/fin/src/Data/Fin.hs
@@ -8,7 +8,13 @@
 {-# LANGUAGE UndecidableInstances #-}
 -- | Finite numbers.
 --
--- This module is designed to be imported qualified.
+-- This module is designed to be imported as
+--
+-- @
+-- import Data.Fin (Fin (..))
+-- import qualified Data.Fin as Fin
+-- @
+--
 module Data.Fin (
     Fin (..),
     cata,
@@ -45,14 +51,15 @@ import Data.Proxy         (Proxy (..))
 import Data.Typeable      (Typeable)
 import GHC.Exception      (ArithException (..), throw)
 import Numeric.Natural    (Natural)
+import Data.Type.Nat (Nat (..))
 
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Type.Nat      as N
 
 -- | Finite numbers: @[0..n-1]@.
-data Fin (n :: N.Nat) where
-    Z :: Fin ('N.S n)
-    S :: Fin n -> Fin ('N.S n)
+data Fin (n :: Nat) where
+    FZ :: Fin ('S n)
+    FS :: Fin n -> Fin ('S n)
   deriving (Typeable)
 
 -------------------------------------------------------------------------------
@@ -77,7 +84,7 @@ instance Show (Fin n) where
 -- *** Exception: divide by zero
 -- ...
 --
--- >>> signum (Z :: Fin N.Nat1)
+-- >>> signum (FZ :: Fin N.Nat1)
 -- 0
 --
 -- >>> signum (3 :: Fin N.Nat4)
@@ -92,9 +99,9 @@ instance Show (Fin n) where
 instance N.SNatI n => Num (Fin n) where
     abs = id
 
-    signum Z         = Z
-    signum (S Z)     = S Z
-    signum (S (S _)) = S Z
+    signum FZ          = FZ
+    signum (FS FZ)     = FS FZ
+    signum (FS (FS _)) = FS FZ
 
     fromInteger = unsafeFromNum . (`mod` (N.reflectToNum (Proxy :: Proxy n)))
 
@@ -140,22 +147,22 @@ inverse = fromInteger . iter 0 n 1 . toInteger where
 instance N.SNatI n => Enum (Fin n) where
     fromEnum = go where
         go :: Fin m -> Int
-        go Z     = 0
-        go (S n) = succ (go n)
+        go FZ     = 0
+        go (FS n) = succ (go n)
 
     toEnum = unsafeFromNum
 
-instance (n ~ 'N.S m, N.SNatI m) => Bounded (Fin n) where
-    minBound = Z
+instance (n ~ 'S m, N.SNatI m) => Bounded (Fin n) where
+    minBound = FZ
     maxBound = getMaxBound $ N.induction
-        (MaxBound Z)
-        (MaxBound . S . getMaxBound)
+        (MaxBound FZ)
+        (MaxBound . FS . getMaxBound)
 
-newtype MaxBound n = MaxBound { getMaxBound :: Fin ('N.S n) }
+newtype MaxBound n = MaxBound { getMaxBound :: Fin ('S n) }
 
 instance NFData (Fin n) where
-    rnf Z     = ()
-    rnf (S n) = rnf n
+    rnf FZ     = ()
+    rnf (FS n) = rnf n
 
 instance Hashable (Fin n) where
     hashWithSalt salt = hashWithSalt salt . cata (0 :: Integer) succ
@@ -167,19 +174,19 @@ instance Hashable (Fin n) where
 -- | 'show' displaying a structure of 'Fin'.
 --
 -- >>> explicitShow (0 :: Fin N.Nat1)
--- "Z"
+-- "FZ"
 --
 -- >>> explicitShow (2 :: Fin N.Nat3)
--- "S (S Z)"
+-- "FS (FS FZ)"
 --
 explicitShow :: Fin n -> String
 explicitShow n = explicitShowsPrec 0 n ""
 
 -- | 'showsPrec' displaying a structure of 'Fin'.
 explicitShowsPrec :: Int -> Fin n -> ShowS
-explicitShowsPrec _ Z     = showString "Z"
-explicitShowsPrec d (S n) = showParen (d > 10)
-    $ showString "S "
+explicitShowsPrec _ FZ     = showString "FZ"
+explicitShowsPrec d (FS n) = showParen (d > 10)
+    $ showString "FS "
     . explicitShowsPrec 11 n
 
 -------------------------------------------------------------------------------
@@ -190,12 +197,12 @@ explicitShowsPrec d (S n) = showParen (d > 10)
 cata :: forall a n. a -> (a -> a) -> Fin n -> a
 cata z f = go where
     go :: Fin m -> a
-    go Z = z
-    go (S n) = f (go n)
+    go FZ = z
+    go (FS n) = f (go n)
 
 -- | Convert to 'Nat'.
 toNat :: Fin n -> N.Nat
-toNat = cata N.Z N.S
+toNat = cata Z S
 
 -- | Convert from 'Nat'.
 --
@@ -207,13 +214,13 @@ toNat = cata N.Z N.S
 --
 fromNat :: N.SNatI n => N.Nat -> Maybe (Fin n)
 fromNat = appNatToFin (N.induction start step) where
-    start :: NatToFin 'N.Z
+    start :: NatToFin 'Z
     start = NatToFin $ const Nothing
 
-    step :: NatToFin n -> NatToFin ('N.S n)
+    step :: NatToFin n -> NatToFin ('S n)
     step (NatToFin f) = NatToFin $ \n -> case n of
-        N.Z   -> Just Z
-        N.S m -> fmap S (f m)
+        Z   -> Just FZ
+        S m -> fmap FS (f m)
 
 newtype NatToFin n = NatToFin { appNatToFin :: N.Nat -> Maybe (Fin n) }
 
@@ -224,16 +231,16 @@ toNatural = cata 0 succ
 -- | Convert from any 'Ord' 'Num'.
 unsafeFromNum :: forall n i. (Num i, Ord i, N.SNatI n) => i -> Fin n
 unsafeFromNum = appUnsafeFromNum (N.induction start step) where
-    start :: UnsafeFromNum i 'N.Z
+    start :: UnsafeFromNum i 'Z
     start = UnsafeFromNum $ \n -> case compare n 0 of
         LT -> throw Underflow
         EQ -> throw Overflow
         GT -> throw Overflow
 
-    step :: UnsafeFromNum i m -> UnsafeFromNum i ('N.S m)
+    step :: UnsafeFromNum i m -> UnsafeFromNum i ('S m)
     step (UnsafeFromNum f) = UnsafeFromNum $ \n -> case compare n 0 of
-        EQ -> Z
-        GT -> S (f (n - 1))
+        EQ -> FZ
+        GT -> FS (f (n - 1))
         LT -> throw Underflow
 
 newtype UnsafeFromNum i n = UnsafeFromNum { appUnsafeFromNum :: i -> Fin n }
@@ -248,17 +255,17 @@ newtype UnsafeFromNum i n = UnsafeFromNum { appUnsafeFromNum :: i -> Fin n }
 -- [0,1,2]
 universe :: N.SNatI n => [Fin n]
 universe = getUniverse $ N.induction (Universe []) step where
-    step :: Universe n -> Universe ('N.S n)
-    step (Universe xs) = Universe (Z : map S xs)
+    step :: Universe n -> Universe ('S n)
+    step (Universe xs) = Universe (FZ : map FS xs)
 
 -- | Like 'universe' but 'NonEmpty'.
 --
 -- >>> universe1 :: NonEmpty (Fin N.Nat3)
 -- 0 :| [1,2]
-universe1 :: N.SNatI n => NonEmpty (Fin ('N.S n))
-universe1 = getUniverse1 $ N.induction (Universe1 (Z :| [])) step where
-    step :: Universe1 n -> Universe1 ('N.S n)
-    step (Universe1 xs) = Universe1 (NE.cons Z (fmap S xs))
+universe1 :: N.SNatI n => NonEmpty (Fin ('S n))
+universe1 = getUniverse1 $ N.induction (Universe1 (FZ :| [])) step where
+    step :: Universe1 n -> Universe1 ('S n)
+    step (Universe1 xs) = Universe1 (NE.cons FZ (fmap FS xs))
 
 -- | 'universe' which will be fully inlined, if @n@ is known at compile time.
 --
@@ -266,18 +273,18 @@ universe1 = getUniverse1 $ N.induction (Universe1 (Z :| [])) step where
 -- [0,1,2]
 inlineUniverse :: N.InlineInduction n => [Fin n]
 inlineUniverse = getUniverse $ N.inlineInduction (Universe []) step where
-    step :: Universe n -> Universe ('N.S n)
-    step (Universe xs) = Universe (Z : map S xs)
+    step :: Universe n -> Universe ('S n)
+    step (Universe xs) = Universe (FZ : map FS xs)
 
 -- | >>> inlineUniverse1 :: NonEmpty (Fin N.Nat3)
 -- 0 :| [1,2]
-inlineUniverse1 :: N.InlineInduction n => NonEmpty (Fin ('N.S n))
-inlineUniverse1 = getUniverse1 $ N.inlineInduction (Universe1 (Z :| [])) step where
-    step :: Universe1 n -> Universe1 ('N.S n)
-    step (Universe1 xs) = Universe1 (NE.cons Z (fmap S xs))
+inlineUniverse1 :: N.InlineInduction n => NonEmpty (Fin ('S n))
+inlineUniverse1 = getUniverse1 $ N.inlineInduction (Universe1 (FZ :| [])) step where
+    step :: Universe1 n -> Universe1 ('S n)
+    step (Universe1 xs) = Universe1 (NE.cons FZ (fmap FS xs))
 
 newtype Universe  n = Universe  { getUniverse  :: [Fin n] }
-newtype Universe1 n = Universe1 { getUniverse1 :: NonEmpty (Fin ('N.S n)) }
+newtype Universe1 n = Universe1 { getUniverse1 :: NonEmpty (Fin ('S n)) }
 
 -- | @'Fin' 'N.Nat0'@ is inhabited.
 absurd :: Fin N.Nat0 -> b
@@ -288,7 +295,7 @@ absurd n = case n of {}
 -- >>> boring
 -- 0
 boring :: Fin N.Nat1
-boring = Z
+boring = FZ
 
 -------------------------------------------------------------------------------
 -- Append & Split
@@ -296,20 +303,20 @@ boring = Z
 
 weakenLeft :: forall n m. N.InlineInduction n => Proxy m -> Fin n -> Fin (N.Plus n m)
 weakenLeft _ = getWeakenLeft (N.inlineInduction start step :: WeakenLeft m n) where
-    start :: WeakenLeft m 'N.Z
+    start :: WeakenLeft m 'Z
     start = WeakenLeft absurd
 
-    step :: WeakenLeft m p -> WeakenLeft m ('N.S p)
+    step :: WeakenLeft m p -> WeakenLeft m ('S p)
     step (WeakenLeft go) = WeakenLeft $ \n -> case n of
-        Z    -> Z
-        S n' -> S (go n')
+        FZ    -> FZ
+        FS n' -> FS (go n')
 
 newtype WeakenLeft m n = WeakenLeft { getWeakenLeft :: Fin n -> Fin (N.Plus n m) }
 
 weakenRight :: forall n m. N.InlineInduction n => Proxy n -> Fin m -> Fin (N.Plus n m)
 weakenRight _ = getWeakenRight (N.inlineInduction start step :: WeakenRight m n) where
     start = WeakenRight id
-    step (WeakenRight go) = WeakenRight $ \x -> S $ go x
+    step (WeakenRight go) = WeakenRight $ \x -> FS $ go x
 
 newtype WeakenRight m n = WeakenRight { getWeakenRight :: Fin m -> Fin (N.Plus n m) }
 
@@ -338,13 +345,13 @@ append (Right m) = weakenRight (Proxy :: Proxy n) m
 --
 split :: forall n m. N.InlineInduction n => Fin (N.Plus n m) -> Either (Fin n) (Fin m)
 split = getSplit (N.inlineInduction start step) where
-    start :: Split m 'N.Z
+    start :: Split m 'Z
     start = Split Right
 
-    step :: Split m p -> Split m ('N.S p)
+    step :: Split m p -> Split m ('S p)
     step (Split go) = Split $ \x -> case x of
-        Z    -> Left Z
-        S x' -> bimap S id $ go x'
+        FZ    -> Left FZ
+        FS x' -> bimap FS id $ go x'
 
 newtype Split m n = Split { getSplit :: Fin (N.Plus n m) -> Either (Fin n) (Fin m) }
 
@@ -352,24 +359,24 @@ newtype Split m n = Split { getSplit :: Fin (N.Plus n m) -> Either (Fin n) (Fin 
 -- Aliases
 -------------------------------------------------------------------------------
 
-fin0 :: Fin (N.Plus N.Nat0 ('N.S n))
-fin1 :: Fin (N.Plus N.Nat1 ('N.S n))
-fin2 :: Fin (N.Plus N.Nat2 ('N.S n))
-fin3 :: Fin (N.Plus N.Nat3 ('N.S n))
-fin4 :: Fin (N.Plus N.Nat4 ('N.S n))
-fin5 :: Fin (N.Plus N.Nat5 ('N.S n))
-fin6 :: Fin (N.Plus N.Nat6 ('N.S n))
-fin7 :: Fin (N.Plus N.Nat7 ('N.S n))
-fin8 :: Fin (N.Plus N.Nat8 ('N.S n))
-fin9 :: Fin (N.Plus N.Nat9 ('N.S n))
+fin0 :: Fin (N.Plus N.Nat0 ('S n))
+fin1 :: Fin (N.Plus N.Nat1 ('S n))
+fin2 :: Fin (N.Plus N.Nat2 ('S n))
+fin3 :: Fin (N.Plus N.Nat3 ('S n))
+fin4 :: Fin (N.Plus N.Nat4 ('S n))
+fin5 :: Fin (N.Plus N.Nat5 ('S n))
+fin6 :: Fin (N.Plus N.Nat6 ('S n))
+fin7 :: Fin (N.Plus N.Nat7 ('S n))
+fin8 :: Fin (N.Plus N.Nat8 ('S n))
+fin9 :: Fin (N.Plus N.Nat9 ('S n))
 
-fin0 = Z
-fin1 = S fin0
-fin2 = S fin1
-fin3 = S fin2
-fin4 = S fin3
-fin5 = S fin4
-fin6 = S fin5
-fin7 = S fin6
-fin8 = S fin7
-fin9 = S fin8
+fin0 = FZ
+fin1 = FS fin0
+fin2 = FS fin1
+fin3 = FS fin2
+fin4 = FS fin3
+fin5 = FS fin4
+fin6 = FS fin5
+fin7 = FS fin6
+fin8 = FS fin7
+fin9 = FS fin8

--- a/fin/src/Data/Fin/Enum.hs
+++ b/fin/src/Data/Fin/Enum.hs
@@ -28,8 +28,8 @@ module Data.Fin.Enum (
 import Prelude hiding (Enum (..))
 
 import Data.Bifunctor (bimap)
-import Data.Fin       (Fin)
-import Data.Nat       (Nat)
+import Data.Fin       (Fin (..))
+import Data.Nat       (Nat (..))
 import Data.Proxy     (Proxy (..))
 import GHC.Generics   ((:+:) (..), M1 (..), U1 (..), V1)
 
@@ -106,7 +106,7 @@ type family EnumSizeRep (a :: * -> *) (n :: Nat) :: Nat where
     EnumSizeRep (a :+: b )   n = EnumSizeRep a (EnumSizeRep b n)
     EnumSizeRep V1           n = n
     EnumSizeRep (M1 _d _c a) n = EnumSizeRep a n
-    EnumSizeRep U1           n = 'N.S n
+    EnumSizeRep U1           n = 'S n
     -- No instance for K1 or :*:
 
 -------------------------------------------------------------------------------
@@ -139,8 +139,8 @@ instance GFromRep V1 where
     gfromSkip _ n = n
 
 instance GFromRep U1 where
-    gfromRep U1 _ = F.Z
-    gfromSkip _ n = F.S n
+    gfromRep U1 _ = FZ
+    gfromSkip _ n = FS n
 
 -------------------------------------------------------------------------------
 -- To
@@ -166,5 +166,5 @@ instance GToRep V1 where
     gtoRep n _ k = k n
 
 instance GToRep U1 where
-    gtoRep F.Z     s _ = s U1
-    gtoRep (F.S n) _ k = k n
+    gtoRep FZ     s _ = s U1
+    gtoRep (FS n) _ k = k n

--- a/fin/test/Inspection.hs
+++ b/fin/test/Inspection.hs
@@ -6,6 +6,7 @@
 {-# OPTIONS_GHC -O -fplugin Test.Inspection.Plugin #-}
 module Main (main) where
 
+import Data.Fin           (Fin (..))
 import Data.Function      (fix)
 import Data.Proxy         (Proxy (..))
 import Data.Tagged        (Tagged (..), retag)
@@ -51,9 +52,9 @@ lhsEnum :: Ordering' -> F.Fin N.Nat3
 lhsEnum = E.gfrom
 
 rhsEnum :: Ordering' -> F.Fin N.Nat3
-rhsEnum LT' = F.Z
-rhsEnum EQ' = F.S F.Z
-rhsEnum GT' = F.S (F.S F.Z)
+rhsEnum LT' = FZ
+rhsEnum EQ' = FS FZ
+rhsEnum GT' = FS (FS FZ)
 
 inspect $ 'lhsEnum ==- 'rhsEnum
 

--- a/vec/ChangeLog.md
+++ b/vec/ChangeLog.md
@@ -1,5 +1,9 @@
 # Revision history for vec
 
+## 0.1.1.1
+
+- Use `fin-0.1`
+
 ## 0.1.1
 
 - Add `Data.Vec.DataFamily.SpineStrict` module

--- a/vec/bench/Bench.hs
+++ b/vec/bench/Bench.hs
@@ -31,17 +31,17 @@ ys = 6 ::: 7 ::: 8 ::: 9 ::: 0 ::: VNil
 
 xsp, ysp :: P.Vec Nat5 Int
 xsp = P.Vec $ \i -> case i of
-    Z               -> 1
-    S Z             -> 2
-    S (S Z)         -> 3
-    S (S (S Z))     -> 4
-    S (S (S (S Z))) -> 5
+    FZ                   -> 1
+    FS FZ                -> 2
+    FS (FS FZ)           -> 3
+    FS (FS (FS FZ))      -> 4
+    FS (FS (FS (FS FZ))) -> 5
 ysp = P.Vec $ \i -> case i of
-    Z               -> 6
-    S Z             -> 7
-    S (S Z)         -> 8
-    S (S (S Z))     -> 9
-    S (S (S (S Z))) -> 0
+    FZ                   -> 6
+    FS FZ                -> 7
+    FS (FS FZ)           -> 8
+    FS (FS (FS FZ))      -> 9
+    FS (FS (FS (FS FZ))) -> 0
 
 main :: IO ()
 main = defaultMain

--- a/vec/src/Data/Vec/DataFamily/SpineStrict.hs
+++ b/vec/src/Data/Vec/DataFamily/SpineStrict.hs
@@ -121,7 +121,7 @@ import Prelude.Compat
 import Control.Applicative (Applicative (..), liftA2)
 import Control.DeepSeq     (NFData (..))
 import Data.Distributive   (Distributive (..))
-import Data.Fin            (Fin)
+import Data.Fin            (Fin (..))
 import Data.Functor.Apply  (Apply (..))
 import Data.Functor.Rep    (Representable (..), distributeRep)
 import Data.Hashable       (Hashable (..))
@@ -348,8 +348,8 @@ toPull = getToPull (N.inlineInduction1 start step) where
 
     step :: ToPull m a -> ToPull ('S m) a
     step (ToPull f) = ToPull $ \(x ::: xs) -> P.Vec $ \i -> case i of
-        F.Z    -> x
-        F.S i' -> P.unVec (f xs) i'
+        FZ    -> x
+        FS i' -> P.unVec (f xs) i'
 
 newtype ToPull n a = ToPull { getToPull :: Vec n a -> P.Vec n a }
 
@@ -360,7 +360,7 @@ fromPull = getFromPull (N.inlineInduction1 start step) where
     start = FromPull $ const VNil
 
     step :: FromPull m a -> FromPull ('S m) a
-    step (FromPull f) = FromPull $ \(P.Vec v) -> v F.Z ::: f (P.Vec (v . F.S))
+    step (FromPull f) = FromPull $ \(P.Vec v) -> v FZ ::: f (P.Vec (v . FS))
 
 newtype FromPull n a = FromPull { getFromPull :: P.Vec n a -> Vec n a }
 
@@ -463,14 +463,14 @@ flipIndex = getIndex (N.inlineInduction1 start step) where
 
     step :: Index m a-> Index ('N.S m) a
     step (Index go) = Index $ \n (x ::: xs) -> case n of
-        F.Z   -> x
-        F.S m -> go m xs
+        FZ   -> x
+        FS m -> go m xs
 
 newtype Index n a = Index { getIndex :: Fin n -> Vec n a -> a }
 
 -- | Indexing.
 --
--- >>> ('a' ::: 'b' ::: 'c' ::: VNil) ! F.S F.Z
+-- >>> ('a' ::: 'b' ::: 'c' ::: VNil) ! FS FZ
 -- 'b'
 --
 (!) :: N.InlineInduction n => Vec n a -> Fin n -> a
@@ -478,15 +478,15 @@ newtype Index n a = Index { getIndex :: Fin n -> Vec n a -> a }
 
 -- | Index lens.
 --
--- >>> ('a' ::: 'b' ::: 'c' ::: VNil) ^. ix (F.S F.Z)
+-- >>> ('a' ::: 'b' ::: 'c' ::: VNil) ^. ix (FS FZ)
 -- 'b'
 --
--- >>> ('a' ::: 'b' ::: 'c' ::: VNil) & ix (F.S F.Z) .~ 'x'
+-- >>> ('a' ::: 'b' ::: 'c' ::: VNil) & ix (FS FZ) .~ 'x'
 -- 'a' ::: 'x' ::: 'c' ::: VNil
 --
 ix :: Fin n -> I.Lens' (Vec n a) a
-ix F.Z     f (x ::: xs) = (::: xs) <$> f x
-ix (F.S n) f (x ::: xs) = (x :::)  <$> ix n f xs
+ix FZ     f (x ::: xs) = (::: xs) <$> f x
+ix (FS n) f (x ::: xs) = (x :::)  <$> ix n f xs
 
 -- | Match on non-empty 'Vec'.
 --
@@ -631,7 +631,7 @@ imap = getIMap $ N.inlineInduction1 start step where
     start = IMap $ \_ _ -> VNil
 
     step :: IMap a m b -> IMap a ('S m) b
-    step (IMap go) = IMap $ \f (x ::: xs) -> f F.Z x ::: go (f . F.S) xs
+    step (IMap go) = IMap $ \f (x ::: xs) -> f FZ x ::: go (f . FS) xs
 
 newtype IMap a n b = IMap { getIMap :: (Fin n -> a -> b) -> Vec n a -> Vec n b }
 
@@ -665,7 +665,7 @@ itraverse = getITraverse $ N.inlineInduction1 start step where
     start = ITraverse $ \_ _ -> pure VNil
 
     step :: ITraverse f a m b -> ITraverse f a ('S m) b
-    step (ITraverse go) = ITraverse $ \f (x ::: xs) -> liftA2 (:::) (f F.Z x) (go (f . F.S) xs)
+    step (ITraverse go) = ITraverse $ \f (x ::: xs) -> liftA2 (:::) (f FZ x) (go (f . FS) xs)
 {-# INLINE itraverse #-}
 
 newtype ITraverse f a n b = ITraverse { getITraverse :: (Fin n -> a -> f b) -> Vec n a -> f (Vec n b) }
@@ -677,7 +677,7 @@ itraverse_ = getITraverse_ $ N.inlineInduction1 start step where
     start = ITraverse_ $ \_ _ -> pure ()
 
     step :: ITraverse_ f a m b -> ITraverse_ f a ('S m) b
-    step (ITraverse_ go) = ITraverse_ $ \f (x ::: xs) -> f F.Z x *> go (f . F.S) xs
+    step (ITraverse_ go) = ITraverse_ $ \f (x ::: xs) -> f FZ x *> go (f . FS) xs
 
 newtype ITraverse_ f a n b = ITraverse_ { getITraverse_ :: (Fin n -> a -> f b) -> Vec n a -> f () }
 
@@ -710,7 +710,7 @@ ifoldMap = getIFoldMap $ N.inlineInduction1 start step where
     start = IFoldMap $ \_ _ -> mempty
 
     step :: IFoldMap a p m -> IFoldMap a ('S p) m
-    step (IFoldMap go) = IFoldMap $ \f (x ::: xs) -> f F.Z x `mappend` go (f . F.S) xs
+    step (IFoldMap go) = IFoldMap $ \f (x ::: xs) -> f FZ x `mappend` go (f . FS) xs
 
 newtype IFoldMap a n m = IFoldMap { getIFoldMap :: (Fin n -> a -> m) -> Vec n a -> m }
 
@@ -718,10 +718,10 @@ newtype IFoldMap a n m = IFoldMap { getIFoldMap :: (Fin n -> a -> m) -> Vec n a 
 ifoldMap1 :: forall a n s. (Semigroup s, N.InlineInduction n) => (Fin ('S n) -> a -> s) -> Vec ('S n) a -> s
 ifoldMap1 = getIFoldMap1 $ N.inlineInduction1 start step where
     start :: IFoldMap1 a 'Z s
-    start = IFoldMap1 $ \f (x ::: _) -> f F.Z x
+    start = IFoldMap1 $ \f (x ::: _) -> f FZ x
 
     step :: IFoldMap1 a p s -> IFoldMap1 a ('S p) s
-    step (IFoldMap1 go) = IFoldMap1 $ \f (x ::: xs) -> f F.Z x <> go (f . F.S) xs
+    step (IFoldMap1 go) = IFoldMap1 $ \f (x ::: xs) -> f FZ x <> go (f . FS) xs
 
 newtype IFoldMap1 a n m = IFoldMap1 { getIFoldMap1 :: (Fin ('S n) -> a -> m) -> Vec ('S n) a -> m }
 
@@ -741,7 +741,7 @@ ifoldr = getIFoldr $ N.inlineInduction1 start step where
     start = IFoldr $ \_ z _ -> z
 
     step :: IFoldr a m b -> IFoldr a ('S m) b
-    step (IFoldr go) = IFoldr $ \f z (x ::: xs) -> f F.Z x (go (f . F.S) z xs)
+    step (IFoldr go) = IFoldr $ \f z (x ::: xs) -> f FZ x (go (f . FS) z xs)
 
 newtype IFoldr a n b = IFoldr { getIFoldr :: (Fin n -> a -> b -> b) -> b -> Vec n a -> b }
 
@@ -804,7 +804,7 @@ izipWith = getIZipWith $ N.inlineInduction start step where
     start = IZipWith $ \_ _ _ -> VNil
 
     step :: IZipWith a b c m -> IZipWith a b c ('S m)
-    step (IZipWith go) = IZipWith $ \f (x ::: xs) (y ::: ys) -> f F.Z x y ::: go (f . F.S) xs ys
+    step (IZipWith go) = IZipWith $ \f (x ::: xs) (y ::: ys) -> f FZ x y ::: go (f . FS) xs ys
 
 newtype IZipWith a b c n = IZipWith { getIZipWith :: (Fin n -> a -> b -> c) -> Vec n a -> Vec n b -> Vec n c }
 
@@ -851,7 +851,7 @@ universe = getUniverse (N.inlineInduction first step) where
     first = Universe VNil
 
     step :: N.InlineInduction m => Universe m -> Universe ('S m)
-    step (Universe go) = Universe (F.Z ::: map F.S go)
+    step (Universe go) = Universe (FZ ::: map FS go)
 
 newtype Universe n = Universe { getUniverse :: Vec n (Fin n) }
 

--- a/vec/src/Data/Vec/DataFamily/SpineStrict/Pigeonhole.hs
+++ b/vec/src/Data/Vec/DataFamily/SpineStrict/Pigeonhole.hs
@@ -43,6 +43,7 @@ import qualified GHC.Generics                    as G
 
 -- $setup
 -- >>> :set -XDeriveGeneric
+-- >>> import Control.Applicative (Const (..))
 -- >>> import Data.Void (absurd)
 -- >>> import GHC.Generics (Generic, Generic1)
 

--- a/vec/src/Data/Vec/Pull.hs
+++ b/vec/src/Data/Vec/Pull.hs
@@ -64,7 +64,7 @@ import Prelude.Compat
 import Control.Applicative (Applicative (..))
 import Control.Lens        ((<&>))
 import Data.Distributive   (Distributive (..))
-import Data.Fin            (Fin)
+import Data.Fin            (Fin (..))
 import Data.Functor.Apply  (Apply (..))
 import Data.Functor.Rep    (Representable (..))
 import Data.Nat
@@ -236,10 +236,10 @@ reifyList (x : xs) f = reifyList xs $ \xs' -> f (cons x xs')
 
 -- | Index lens.
 --
--- >>> ('a' L.::: 'b' L.::: 'c' L.::: L.VNil) ^. L._Pull . ix (F.S F.Z)
+-- >>> ('a' L.::: 'b' L.::: 'c' L.::: L.VNil) ^. L._Pull . ix (FS FZ)
 -- 'b'
 --
--- >>> ('a' L.::: 'b' L.::: 'c' L.::: L.VNil) & L._Pull . ix (F.S F.Z) .~ 'x'
+-- >>> ('a' L.::: 'b' L.::: 'c' L.::: L.VNil) & L._Pull . ix (FS FZ) .~ 'x'
 -- 'a' ::: 'x' ::: 'c' ::: VNil
 --
 ix :: Fin n -> I.Lens' (Vec n a) a
@@ -254,7 +254,7 @@ ix i f (Vec v) = f (v i) <&> \a -> Vec $ \j ->
 -- In fact, @'Vec' n a@ cannot have an instance of 'I.Cons' as types don't match.
 --
 _Cons :: I.Iso (Vec ('S n) a) (Vec ('S n) b) (a, Vec n a) (b, Vec n b)
-_Cons = I.iso (\(Vec v) -> (v F.Z, Vec (v . F.S))) (\(x, xs) -> cons x xs)
+_Cons = I.iso (\(Vec v) -> (v FZ, Vec (v . FS))) (\(x, xs) -> cons x xs)
 
 -- | Head lens. /Note:/ @lens@ 'I._head' is a 'I.Traversal''.
 --
@@ -265,28 +265,28 @@ _Cons = I.iso (\(Vec v) -> (v F.Z, Vec (v . F.S))) (\(x, xs) -> cons x xs)
 -- 'x' ::: 'b' ::: 'c' ::: VNil
 --
 _head :: I.Lens' (Vec ('S n) a) a
-_head f (Vec v) = f (v F.Z) <&> \a -> Vec $ \j -> case j of
-    F.Z -> a
+_head f (Vec v) = f (v FZ) <&> \a -> Vec $ \j -> case j of
+    FZ -> a
     _   -> v j
 {-# INLINE head #-}
 
 -- | Head lens. /Note:/ @lens@ 'I._head' is a 'I.Traversal''.
 _tail :: I.Lens' (Vec ('S n) a) (Vec n a)
-_tail f (Vec v) = f (Vec (v . F.S)) <&> \xs -> cons (v F.Z) xs
+_tail f (Vec v) = f (Vec (v . FS)) <&> \xs -> cons (v FZ) xs
 {-# INLINE _tail #-}
 
 cons :: a -> Vec n a -> Vec ('S n) a
 cons x (Vec v) = Vec $ \i -> case i of
-    F.Z   -> x
-    F.S j -> v j
+    FZ   -> x
+    FS j -> v j
 
 -- | The first element of a 'Vec'.
 head :: Vec ('S n) a -> a
-head (Vec v) = v F.Z
+head (Vec v) = v FZ
 
 -- | The elements after the 'head' of a 'Vec'.
 tail :: Vec ('S n) a -> Vec n a
-tail (Vec v) = Vec (v . F.S)
+tail (Vec v) = Vec (v . FS)
 
 -------------------------------------------------------------------------------
 -- Mapping

--- a/vec/test/Inspection.hs
+++ b/vec/test/Inspection.hs
@@ -5,6 +5,7 @@ module Inspection where
 
 import Prelude hiding (zipWith)
 
+import Data.Fin        (Fin (..))
 import Data.Vec.Lazy   (Vec (..))
 import Test.Inspection
 
@@ -48,7 +49,7 @@ lhsIMap' :: Vec N.Nat2 (F.Fin N.Nat2, Char)
 lhsIMap' = L.imap (,) $ 'a' ::: 'b' ::: VNil
 
 rhsIMap :: Vec N.Nat2 (F.Fin N.Nat2, Char)
-rhsIMap = (F.Z,'a') ::: (F.S F.Z,'b') ::: VNil
+rhsIMap = (FZ,'a') ::: (FS FZ,'b') ::: VNil
 
 inspect $ 'lhsIMap  === 'rhsIMap
 inspect $ 'lhsIMap' =/= 'rhsIMap

--- a/vec/test/Inspection/DataFamily/SpineStrict.hs
+++ b/vec/test/Inspection/DataFamily/SpineStrict.hs
@@ -6,7 +6,8 @@ module Inspection.DataFamily.SpineStrict where
 
 import Prelude hiding (zipWith)
 
-import Data.Vec.DataFamily.SpineStrict   (Vec (..))
+import Data.Fin                        (Fin (..))
+import Data.Vec.DataFamily.SpineStrict (Vec (..))
 import Test.Inspection
 
 import qualified Data.Fin                        as F
@@ -40,7 +41,7 @@ lhsIMap :: Vec N.Nat2 (F.Fin N.Nat2, Char)
 lhsIMap = I.imap (,) $ 'a' ::: 'b' ::: VNil
 
 rhsIMap :: Vec N.Nat2 (F.Fin N.Nat2, Char)
-rhsIMap = (F.Z,'a') ::: (F.S F.Z,'b') ::: VNil
+rhsIMap = (FZ,'a') ::: (FS FZ,'b') ::: VNil
 
 inspect $ 'lhsIMap  === 'rhsIMap
 

--- a/vec/vec.cabal
+++ b/vec/vec.cabal
@@ -1,7 +1,6 @@
 cabal-version:      >=1.10
 name:               vec
-version:            0.1.1
-x-revision:         1
+version:            0.1.1.1
 synopsis:           Vec: length-indexed (sized) list
 category:           Data, Dependent Types
 description:
@@ -92,7 +91,7 @@ library
     , base-compat    >=0.9.3   && <0.11
     , deepseq        >=1.3.0.2 && <1.5
     , distributive   >=0.5.3   && <0.7
-    , fin            >=0.0.2   && <0.1
+    , fin            >=0.1     && <0.2
     , hashable       >=1.2.7.0 && <1.4
     , lens           >=4.16    && <4.18
     , semigroupoids  >=5.2.2   && <5.4


### PR DESCRIPTION
So we can

```qualified
import Data.Nat (Nat (..))
import Data.Fin (Fin (..))
```

That feels a lot better.