### PR TITLE
Added snoc to Data.Vec.Lazy and Data.Vec.Pull.

### DIFF
--- a/vec/src/Data/Vec/Lazy.hs
+++ b/vec/src/Data/Vec/Lazy.hs
@@ -34,6 +34,7 @@ module Data.Vec.Lazy (
     _head,
     _tail,
     cons,
+    snoc,
     head,
     tail,
     -- * Concatenation and splitting
@@ -432,6 +433,11 @@ _tail f (x ::: xs) = (x :::) <$> f xs
 -- | Cons an element in front of a 'Vec'.
 cons :: a -> Vec n a -> Vec ('S n) a
 cons = (:::)
+
+-- | Add a single element at the end of a 'Vec'.
+snoc :: a -> Vec n a -> Vec ('S n) a
+snoc a VNil = a ::: VNil
+snoc a (x ::: xs) = x ::: snoc a xs
 
 -- | The first element of a 'Vec'.
 head :: Vec ('S n) a -> a

--- a/vec/src/Data/Vec/Pull.hs
+++ b/vec/src/Data/Vec/Pull.hs
@@ -28,6 +28,8 @@ module Data.Vec.Pull (
     _Cons,
     _head,
     _tail,
+    cons,
+    snoc,
     head,
     tail,
     -- * Folds
@@ -64,7 +66,9 @@ import Prelude.Compat
 import Control.Applicative (Applicative (..))
 import Control.Lens        ((<&>))
 import Data.Distributive   (Distributive (..))
+import Data.Either         (Either(Left, Right))
 import Data.Fin            (Fin (..))
+import qualified Data.Fin as Fin (split)
 import Data.Functor.Apply  (Apply (..))
 import Data.Functor.Rep    (Representable (..))
 import Data.Nat
@@ -279,6 +283,15 @@ cons :: a -> Vec n a -> Vec ('S n) a
 cons x (Vec v) = Vec $ \i -> case i of
     FZ   -> x
     FS j -> v j
+
+snoc :: forall a n. (N.InlineInduction n, N.Plus n ('S 'Z) ~ 'S n) => a -> Vec n a -> Vec ('S n) a
+snoc x (Vec v) = Vec $ \i ->
+  case Fin.split i :: Either (Fin n) (Fin ('S 'Z)) of
+    Left finN ->
+      v finN
+
+    Right _ ->
+      x
 
 -- | The first element of a 'Vec'.
 head :: Vec ('S n) a -> a


### PR DESCRIPTION
I've added snoc to `Data.Vec.Lazy` and `Data.Vec.Pull`, like in `Data.Vec.Sized`. I couldn't figure out how to do the `Pull` version without the `N.Plus n ('S 'Z) ~ 'S n` constraint. Any thoughts? If this approach is okay, I'd be interested in implementing the mentioned missing parts in `Pull`.