### PR TITLE
add last, init and toNonEmpty function to vec

### DIFF
--- a/vec/src/Data/Vec/Lazy.hs
+++ b/vec/src/Data/Vec/Lazy.hs
@@ -23,6 +23,7 @@ module Data.Vec.Lazy (
     toPull,
     fromPull,
     toList,
+    toNonEmpty,
     fromList,
     fromListPrefix,
     reifyList,
@@ -32,7 +33,9 @@ module Data.Vec.Lazy (
     cons,
     snoc,
     head,
+    last,
     tail,
+    init,
     -- * Reverse
     reverse,
     -- * Concatenation and splitting
@@ -88,6 +91,7 @@ import Control.DeepSeq     (NFData (..))
 import Control.Lens.Yocto  ((<&>))
 import Data.Fin            (Fin (..))
 import Data.Hashable       (Hashable (..))
+import Data.List.NonEmpty  (NonEmpty (..))
 import Data.Monoid         (Monoid (..))
 import Data.Nat            (Nat (..))
 import Data.Semigroup      (Semigroup (..))
@@ -309,6 +313,11 @@ toList :: Vec n a -> [a]
 toList VNil       = []
 toList (x ::: xs) = x : toList xs
 
+-- >>> toNonEmpty $ 1 ::: 2 ::: 3 ::: VNil
+-- 1 :| [2, 3]
+toNonEmpty :: Vec ('S n) a -> NonEmpty a
+toNonEmpty (x ::: xs) = x :| toList xs
+
 -- | Convert list @[a]@ to @'Vec' n a@.
 -- Returns 'Nothing' if lengths don't match exactly.
 --
@@ -402,9 +411,19 @@ snoc (y ::: ys) x = y ::: snoc ys x
 head :: Vec ('S n) a -> a
 head (x ::: _) = x
 
+-- | The last element of a 'Vec'.
+last :: Vec ('S n) a -> a
+last (x ::: VNil) = x
+last (_ ::: xs@(_ ::: _)) = last xs
+
 -- | The elements after the 'head' of a 'Vec'.
 tail :: Vec ('S n) a -> Vec n a
 tail (_ ::: xs) = xs
+
+-- | The elements before the 'last' of a 'Vec'.
+init :: Vec ('S n) a -> Vec n a
+init (_ ::: VNil) = VNil
+init (x ::: xs@(_ ::: _)) = x ::: init xs
 
 -------------------------------------------------------------------------------
 -- Reverse

--- a/vec/src/Data/Vec/Pull.hs
+++ b/vec/src/Data/Vec/Pull.hs
@@ -20,6 +20,7 @@ module Data.Vec.Pull (
     singleton,
     -- * Conversions
     toList,
+    toNonEmpty,
     fromList,
     fromListPrefix,
     reifyList,
@@ -29,7 +30,9 @@ module Data.Vec.Pull (
     cons,
     snoc,
     head,
+    last,
     tail,
+    init,
     -- * Reverse
     reverse,
     -- * Folds
@@ -61,7 +64,7 @@ module Data.Vec.Pull (
 
 import Prelude
        (Bool (..), Eq (..), Functor (..), Int, Maybe (..), Monad (..), Num (..),
-       all, const, id, maybe, ($), (.))
+       all, const, id, maxBound, maybe, ($), (.))
 
 import Control.Applicative (Applicative (..), (<$>))
 import Data.Fin            (Fin (..))
@@ -206,6 +209,10 @@ singleton = Vec . const
 toList :: N.SNatI n => Vec n a -> [a]
 toList v = unVec v <$> F.universe
 
+-- | Convert 'Vec' to NonEmpty.
+toNonEmpty :: N.SNatI n => Vec ('S n) a -> NonEmpty a
+toNonEmpty v = head v :| toList (tail v)
+
 -- | Convert list @[a]@ to @'Vec' n a@.
 -- Returns 'Nothing' if lengths don't match exactly.
 --
@@ -290,9 +297,17 @@ snoc (Vec xs) x = Vec $ \i -> maybe x xs (F.isMax i)
 head :: Vec ('S n) a -> a
 head (Vec v) = v FZ
 
+-- | The last element of a 'Vec'.
+last :: forall n a. N.SNatI n => Vec ('S n) a -> a
+last (Vec v) = v maxBound 
+
 -- | The elements after the 'head' of a 'Vec'.
 tail :: Vec ('S n) a -> Vec n a
 tail (Vec v) = Vec (v . FS)
+
+-- | The elements before the 'last' of a 'Vec'.
+init :: forall n a. N.SNatI n => Vec ('S n) a -> Vec n a
+init (Vec v) = Vec (v . F.weakenLeft1)
 
 -------------------------------------------------------------------------------
 -- Reverse

--- a/vec/test/Inspection.hs
+++ b/vec/test/Inspection.hs
@@ -6,6 +6,7 @@ module Inspection where
 import Prelude hiding (zipWith)
 
 import Data.Fin        (Fin (..))
+import Data.List.NonEmpty (NonEmpty (..))
 import Data.Vec.Lazy   (Vec (..))
 import Test.Inspection
 
@@ -119,3 +120,51 @@ rhsReverse = 'a' ::: 'b' ::: 'c' ::: VNil
 
 inspect $ 'lhsReverse  === 'rhsReverse
 inspect $ 'lhsReverse' =/= 'rhsReverse
+
+-------------------------------------------------------------------------------
+-- last
+-------------------------------------------------------------------------------
+
+lhsLast :: Char
+lhsLast = I.last $ 'a' ::: 'b' ::: 'c' ::: VNil
+
+lhsLast' :: Char
+lhsLast' = L.last $ 'a' ::: 'b' ::: 'c' :::VNil
+
+rhsLast :: Char 
+rhsLast = 'c'
+
+inspect $ 'lhsLast === 'rhsLast
+inspect $ 'lhsLast' =/= 'rhsLast
+
+-------------------------------------------------------------------------------
+-- init
+-------------------------------------------------------------------------------
+
+lhsInit :: Vec N.Nat2 Char
+lhsInit = I.init $ 'a' ::: 'b' ::: 'c' ::: VNil
+
+lhsInit' :: Vec N.Nat2 Char
+lhsInit' = L.init $ 'a' ::: 'b' ::: 'c' ::: VNil
+
+rhsInit :: Vec N.Nat2 Char
+rhsInit = 'a' ::: 'b' ::: VNil
+
+inspect $ 'lhsInit  === 'rhsInit
+inspect $ 'lhsInit' =/= 'rhsInit
+
+-------------------------------------------------------------------------------
+-- toNonEmpty
+-------------------------------------------------------------------------------
+
+lhsToNonEmpty :: NonEmpty Char
+lhsToNonEmpty = I.toNonEmpty $ 'a' ::: 'b' ::: 'c' ::: VNil
+
+lhsToNonEmpty' :: NonEmpty Char
+lhsToNonEmpty' = L.toNonEmpty $ 'a' ::: 'b' ::: 'c' ::: VNil
+
+rhsToNonEmpty :: NonEmpty Char
+rhsToNonEmpty = 'a' :| ['b', 'c']
+
+inspect $ 'lhsToNonEmpty  === 'rhsToNonEmpty
+inspect $ 'lhsToNonEmpty' =/= 'rhsToNonEmpty


### PR DESCRIPTION
This adds a `last`, `init` and `toNonEmpty` function to `Data.Vec.Lazy`, `Data.Vec.Lazy.Inline` and `Data.Vec.Pull`.