### PR TITLE
support GHC 9.8 (base 4.19) and deepseq 1.5

### DIFF
--- a/bin/bin.cabal
+++ b/bin/bin.cabal
@@ -46,6 +46,7 @@ tested-with:
    || ==9.2.7
    || ==9.4.4
    || ==9.6.1
+   || ==9.8.1
 
 source-repository head
   type:     git
@@ -67,10 +68,10 @@ library
 
   other-modules:    TrustworthyCompat
   build-depends:
-    , base        >=4.7     && <4.19
+    , base        >=4.7     && <4.20
     , boring      ^>=0.2
     , dec         ^>=0.0.3
-    , deepseq     >=1.3.0.2 && <1.5
+    , deepseq     >=1.3.0.2 && <1.6
     , fin         ^>=0.3
     , hashable    >=1.2.7.0 && <1.5
     , QuickCheck  ^>=2.14.2

--- a/fin/fin.cabal
+++ b/fin/fin.cabal
@@ -69,6 +69,7 @@ tested-with:
    || ==9.2.7
    || ==9.4.4
    || ==9.6.1
+   || ==9.8.1
 
 source-repository head
   type:     git
@@ -89,10 +90,10 @@ library
 
   other-modules:    TrustworthyCompat
   build-depends:
-      base           >=4.7     && <4.19
+      base           >=4.7     && <4.20
     , boring         >=0.2     && <0.3
     , dec            >=0.0.4   && <0.1
-    , deepseq        >=1.3.0.2 && <1.5
+    , deepseq        >=1.3.0.2 && <1.6
     , hashable       >=1.2.7.0 && <1.5
     , QuickCheck     >=2.13.2  && <2.15
     , some           >=1.0.4   && <1.1

--- a/ral-lens/ral-lens.cabal
+++ b/ral-lens/ral-lens.cabal
@@ -30,6 +30,7 @@ tested-with:
    || ==9.2.7
    || ==9.4.4
    || ==9.6.1
+   || ==9.8.1
 
 source-repository head
   type:     git
@@ -49,7 +50,7 @@ library
     Data.RAVec.Tree.Lens
 
   build-depends:
-    , base  >=4.7   && <4.19
+    , base  >=4.7   && <4.20
     , bin   ^>=0.1
     , fin   ^>=0.2 || ^>=0.3
     , lens  >=4.16  && <5.3

--- a/ral-optics/ral-optics.cabal
+++ b/ral-optics/ral-optics.cabal
@@ -28,6 +28,7 @@ tested-with:
    || ==9.2.7
    || ==9.4.4
    || ==9.6.1
+   || ==9.8.1
 
 source-repository head
   type:     git
@@ -51,7 +52,7 @@ library
     Data.RAVec.NonEmpty.Optics.Internal
 
   build-depends:
-    , base         >=4.9 && <4.19
+    , base         >=4.9 && <4.20
     , bin          ^>=0.1
     , fin          ^>=0.2 || ^>=0.3
     , optics-core  >=0.2 && <0.5

--- a/ral/ral.cabal
+++ b/ral/ral.cabal
@@ -42,6 +42,7 @@ tested-with:
    || ==9.2.7
    || ==9.4.4
    || ==9.6.1
+   || ==9.8.1
 
 
 source-repository head
@@ -89,8 +90,8 @@ library
 
   -- GHC boot libs
   build-depends:
-    , base     >=4.7     && <4.19
-    , deepseq  >=1.3.0.1 && <1.5
+    , base     >=4.7     && <4.20
+    , deepseq  >=1.3.0.1 && <1.6
 
   if !impl(ghc >=8.0)
     build-depends: semigroups >=0.18.5 && <0.21

--- a/vec-lens/vec-lens.cabal
+++ b/vec-lens/vec-lens.cabal
@@ -33,6 +33,7 @@ tested-with:
    || ==9.2.7
    || ==9.4.4
    || ==9.6.1
+   || ==9.8.1
 
 source-repository head
   type:     git
@@ -51,7 +52,7 @@ library
     Data.Vec.Pull.Lens
 
   -- GHC boot libs
-  build-depends:    base >=4.7 && <4.19
+  build-depends:    base >=4.7 && <4.20
 
   -- siblings
   build-depends:

--- a/vec-optics/vec-optics.cabal
+++ b/vec-optics/vec-optics.cabal
@@ -31,6 +31,7 @@ tested-with:
    || ==9.2.7
    || ==9.4.4
    || ==9.6.1
+   || ==9.8.1
 
 source-repository head
   type:     git
@@ -49,7 +50,7 @@ library
     Data.Vec.Pull.Optics
 
   -- GHC boot libs
-  build-depends:    base >=4.9 && <4.19
+  build-depends:    base >=4.9 && <4.20
 
   -- siblings
   build-depends:

--- a/vec/vec.cabal
+++ b/vec/vec.cabal
@@ -82,6 +82,7 @@ tested-with:
    || ==9.2.7
    || ==9.4.4
    || ==9.6.1
+   || ==9.8.1
 
 source-repository head
   type:     git
@@ -123,8 +124,8 @@ library
 
   -- GHC boot libs
   build-depends:
-    , base          >=4.7     && <4.19
-    , deepseq       >=1.3.0.1 && <1.5
+    , base          >=4.7     && <4.20
+    , deepseq       >=1.3.0.1 && <1.6
     , transformers  >=0.3.0.0 && <0.7
 
   if !impl(ghc >=8.0)


### PR DESCRIPTION
The tests pass, albeit with a bunch of allow-newers:

```
allow-newer: some-1.0.5:base, some-1.0.5:template-haskell, some-1.0.5:deepseq
allow-newer: dec-0.0.5:base
allow-newer: boring-0.2.1:base
allow-newer: universe-base-1.1.3.1:base
allow-newer: vector-th-unbox-0.2.2:base, vector-th-unbox-0.2.2:template-haskell
allow-newer: microstache-1.0.2.3:base, microstache-1.0.2.3:deepseq, microstache-1.0.2.3:text
allow-newer: attoparsec-0.14.4:ghc-prim
allow-newer: binary-orphans-1.0.4.1:base
allow-newer: network-uri-2.6.4.2:deepseq
```

Let me know if I should check them into `cabal.project`, as I see traces from similar previous bumps.